### PR TITLE
chore: 调整前端 repo 打包 workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,12 +6,15 @@ on:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: image-builder
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build and push
       uses: byzanteam/jet-actions/fe-build-image@main
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        registries: |-
+          ${{ secrets.ALIYUN_SKYLARK_REGISTRY }}
+          ghcr.io,byzanteam,${{ github.repository_owner }},${{ github.token }}
+        cache_type: local


### PR DESCRIPTION
### 遵循以下步骤修改：
- 修改 workflow 文件中 `run-on` 字段变为 `image-builder`，使用自建的 self hosted 进行打包 
- 修改 `Checkout` 步骤中 actions 版本为 v3
- 修改 `Build and push` 步骤中以下参数:
  - 删除 `github_token` 变量
  - 添加 `registries` 变量: 
    ```yaml
     registries: |-
       ${{ secrets.ALIYUN_SKYLARK_REGISTRY }}
       ghcr.io,byzanteam,${{ github.repository_owner }},${{ github.token }}
    ```
    - skylark 相关项目使用 `${{ secrets.ALIYUN_SKYLARK_REGISTRY }}` 变量
    - jet 相关项目使用 `${{ secrets.ALIYUN_JET_REGISTRY }}` 变量
  - 添加 cache_type 变量：
    ```yaml
     cache_type: local
    ```


### Links
- action doc: https://github.com/Byzanteam/jet-actions/tree/main/fe-build-image
